### PR TITLE
window.settings.js save error fix

### DIFF
--- a/assets/components/clientconfig/js/mgr/widgets/window.settings.js
+++ b/assets/components/clientconfig/js/mgr/widgets/window.settings.js
@@ -97,7 +97,7 @@ ClientConfig.window.Setting = function(config) {
                     anchor: '100%',
                     hidden: (config.record && (config.record.xtype === 'modx-combo')) ? false : true
                 }
-                ,this.getSourceField()
+                ,this.getSourceField(config)
                 ,{
                     xtype: 'checkbox',
                     name: 'is_required',
@@ -111,7 +111,7 @@ ClientConfig.window.Setting = function(config) {
     ClientConfig.window.Setting.superclass.constructor.call(this,config);
 };
 Ext.extend(ClientConfig.window.Setting,MODx.Window,{
-    getSourceField: function(){
+    getSourceField: function(config){
         var isImageTV = (config.record && (['modx-panel-tv-image', 'modx-panel-tv-file'].indexOf(config.record.xtype) !== -1)) ? true : false;
         var sourcefield = {
             xtype: 'modx-combo-source',
@@ -122,8 +122,9 @@ Ext.extend(ClientConfig.window.Setting,MODx.Window,{
             anchor: '100%',
             hidden: !isImageTV,
             hideMode: 'offsets'
-        }
-        if(!isImageTv) sourcefield.value = 0
+        };
+        if(!isImageTV) sourcefield.value = 0;
         return sourcefield;
+    }
 });
 Ext.reg('clientconfig-window-setting',ClientConfig.window.Setting);

--- a/assets/components/clientconfig/js/mgr/widgets/window.settings.js
+++ b/assets/components/clientconfig/js/mgr/widgets/window.settings.js
@@ -96,16 +96,9 @@ ClientConfig.window.Setting = function(config) {
                     description: _('clientconfig.options.desc'),
                     anchor: '100%',
                     hidden: (config.record && (config.record.xtype === 'modx-combo')) ? false : true
-                },{
-                    xtype: 'modx-combo-source',
-                    id: config.id + '-source',
-                    name: 'source',
-                    fieldLabel: _('clientconfig.source'),
-                    description: _('clientconfig.source.desc'),
-                    anchor: '100%',
-                    hidden: (config.record && (['modx-panel-tv-image', 'modx-panel-tv-file'].indexOf(config.record.xtype) !== -1)) ? false : true,
-                    hideMode: 'offsets'
-                },{
+                }
+                ,this.getSourceField()
+                ,{
                     xtype: 'checkbox',
                     name: 'is_required',
                     boxLabel: _('clientconfig.is_required.long'),
@@ -117,5 +110,20 @@ ClientConfig.window.Setting = function(config) {
     });
     ClientConfig.window.Setting.superclass.constructor.call(this,config);
 };
-Ext.extend(ClientConfig.window.Setting,MODx.Window);
+Ext.extend(ClientConfig.window.Setting,MODx.Window,{
+    getSourceField: function(){
+        var isImageTV = (config.record && (['modx-panel-tv-image', 'modx-panel-tv-file'].indexOf(config.record.xtype) !== -1)) ? true : false;
+        var sourcefield = {
+            xtype: 'modx-combo-source',
+            id: config.id + '-source',
+            name: 'source',
+            fieldLabel: _('clientconfig.source'),
+            description: _('clientconfig.source.desc'),
+            anchor: '100%',
+            hidden: !isImageTV,
+            hideMode: 'offsets'
+        }
+        if(!isImageTv) sourcefield.value = 0
+        return sourcefield;
+});
 Ext.reg('clientconfig-window-setting',ClientConfig.window.Setting);


### PR DESCRIPTION
### What does it do ?
Fixes a bug in PHP 7+ and MySQL 5.7+ where data types are not changed to the correct database default if entered as an invalid data type.  Fix also avoids displaying the default value of "0" if the setting is an image field.

### Why is it needed ?
The "source" field did not have a default value in the form and was passing and empty string.  This was not being converted to the correct default of 0 before attempting to run the query.  Adding the default value of 0 only if the setting has not been set as an image field resolves the issue and does not effect the field display when the setting has been set as an image.

### Related issue(s)/PR(s)