### PR TITLE
Correctly populate file-type fields on context change

### DIFF
--- a/core/components/clientconfig/processors/mgr/settings/getcontextaware.class.php
+++ b/core/components/clientconfig/processors/mgr/settings/getcontextaware.class.php
@@ -33,11 +33,18 @@ class cgSettingsGetContextAwareProcessor extends modProcessor {
             /** @var cgContextValue $cg */
             $key = $cv->get('setting_key');
             $value = $cv->get('value');
+            // Set is media to false
+            $isMedia = false;
             switch ($cv->get('setting_xtype')) {
                 case 'checkbox':
                 case 'xcheckbox':
                     $value = (bool)$value;
                     break;
+                // If this looks like a media type, set isMedia to true
+                case 'modx-panel-tv-image':
+                case 'modx-panel-tv-file':
+                	$isMedia = true;
+					break;
             }
 
             if ($value === '') {
@@ -45,6 +52,13 @@ class cgSettingsGetContextAwareProcessor extends modProcessor {
             }
 
             $values[$key] = $value;
+            
+            /* If this is a media type, set additional named placeholders so
+               .setValues() populates the values on context change */
+			if($isMedia) {
+				$values['tv'.$key] = $value;
+				$values['tvbrowser'.$key] = $value;
+			}
         }
 
         return $this->success('', $values);


### PR DESCRIPTION
Add additional values to the array sent back for file & image type fields only so they populate the fields correctly on context change.

### What does it do ?
Checks if a field type is an image or file and sets two additional values in the returned JSON so that form.setValues() can do its job properly.

### Why is it needed ?
These fields weren't being repopulated on context change which was leading to oversaving of the default/global value on each save following the main page load. (Main page loads, brings default value, context change does nothing, next save overwrites context value with still-present global/default vale).

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request 
This should resolve #147 
