### PR TITLE
fixes language file to avoid ambiguous meanings

### DIFF
--- a/core/components/clientconfig/lexicon/de/default.inc.php
+++ b/core/components/clientconfig/lexicon/de/default.inc.php
@@ -107,4 +107,4 @@ $_lang['clientconfig.choose_context'] = 'Kontext wählen';
 $_lang['clientconfig.global_values'] = 'Global';
 $_lang['clientconfig.config_for_context'] = 'Konfiguration für [[+context]]';
 $_lang['clientconfig.categories'] = 'Kategorien';
-$_lang['clientconfig.process_options'] = 'Tags in Optionen verarbeiten';
+$_lang['clientconfig.process_options'] = 'MODX-Syntax in Optionen auswerten';


### PR DESCRIPTION
Changes the field description to avoid the generic word "tag", that could mean anything. This way it's obvious that MODX-syntax is supposed to be processed. The previous version translated to "work with tags in options".