### PR TITLE
Added pdoToolsOnFenomInit system event

### DIFF
--- a/_build/events/events.clientconfig.php
+++ b/_build/events/events.clientconfig.php
@@ -4,6 +4,7 @@ $events = array();
 
 $e = array(
     'OnMODXInit',
+    'pdoToolsOnFenomInit',
 );
 
 foreach ($e as $ev) {

--- a/core/components/clientconfig/elements/plugins/clientconfig.plugin.php
+++ b/core/components/clientconfig/elements/plugins/clientconfig.plugin.php
@@ -35,6 +35,7 @@ $eventName = $modx->event->name;
 switch($eventName) {
     case 'OnMODXInit':
     case 'OnHandleRequest':
+    case 'pdoToolsOnFenomInit':
         /* Grab the class */
         $path = $modx->getOption('clientconfig.core_path', null, $modx->getOption('core_path') . 'components/clientconfig/');
         $path .= 'model/clientconfig/';


### PR DESCRIPTION
### Why is it needed ?
In templates inherited via Fenom, ClientConfig settings do not work without this event, as an example - templates for emails in miniShop2.

### Related issue(s)/PR(s)
https://github.com/modmore/ClientConfig/issues/173
