### PR TITLE
Added an icon for the menu

### DIFF
--- a/_build/data/transport.menus.php
+++ b/_build/data/transport.menus.php
@@ -10,6 +10,7 @@ $menu->fromArray(array(
     'namespace' => 'clientconfig',
     'params' => '',
     'handler' => '',
+    'icon' => '<i class="icon icon-wrench"></i>',
 ),'',true,true);
 
 $vehicle = $builder->createVehicle($menu,array (


### PR DESCRIPTION
### What does it do ?
Often ClientConfig is needed in the main menu, more convenient for the user. And to make it easier to find the menu item - added an icon.

![top-icon](https://user-images.githubusercontent.com/12523676/67091118-e2a32880-f1bc-11e9-8179-000e4546263f.png)
