### PR TITLE
Allow 0 as value in multi-context settings

### DIFF
--- a/core/components/clientconfig/model/clientconfig/clientconfig.class.php
+++ b/core/components/clientconfig/model/clientconfig/clientconfig.class.php
@@ -109,7 +109,7 @@ class ClientConfig {
                         if ($isMedia) {
                             $value = $setting->prefixSourceUrl($value);
                         }
-                        if (!empty($value)) {
+                        if (!empty($value) || $value === '0') {
                             $settings['contexts'][$cKey][$setting->get('key')] = $value;
                         }
                     }


### PR DESCRIPTION
### What does it do?

This accepts 0 values as non-empty for multi-context settings.

### Why is it needed?

When using ClientConfig in multi-context mode, you can't set an actual value of 0 (tested with numberfield and selectbox). This causes the setting to fall back on the global value.

I don't know if this is a bug or a design choice, but in my opinion 0 does not always equate to empty here. So I propose to return 0 as context-specific value, instead of the global fallback.

### Remarks

I hope this won't break anyone's existing setup. It's also a little tricky to select a truly empty option in a selectbox, because the following doesn't work:

```
Global==||Low==0||Medium==1||High==2
```

In this case, `Global` is returned if you select the first option. Also a little bug maybe? Because this would work with TVs.. In any case, this does work:

```
||Low==0||Medium==1||High==2
```

This renders and empty first option and when selected, the global value is returned. Not the prettiest solution, but at least it allows you to replicate the old behaviour. A reset option similar to the one for TVs would be nice here of course, but that's probably a little too much to ask for ;)
