### PR TITLE
Lower OnHandleRequest priority to 1 when packaged

### DIFF
--- a/_build/events/events.clientconfig.php
+++ b/_build/events/events.clientconfig.php
@@ -12,7 +12,8 @@ foreach ($e as $ev) {
     $events[$ev] = $modx->newObject('modPluginEvent');
     $events[$ev]->fromArray(array(
         'event' => $ev,
-        'priority' => 0,
+        // Lower OnHandleRequest priority to 1, to work reliably out of the box with context router plugins.
+        'priority' => $ev === 'OnHandleRequest' ? 1 : 0, 
         'propertyset' => 0
     ),'',true,true);
 }


### PR DESCRIPTION
Lowers `OnHandleRequest` priority to `1` so that context routing plugins can reliably run first.