### PR TITLE
Invoke ClientConfig_ConfigChange event after clearing caches

### DIFF
--- a/core/components/clientconfig/processors/mgr/settings/save.class.php
+++ b/core/components/clientconfig/processors/mgr/settings/save.class.php
@@ -68,11 +68,11 @@ class cgSettingSaveProcessor extends modProcessor {
         }
 
         // Invoke events and clear the cache
-        $this->modx->invokeEvent('ClientConfig_ConfigChange');
         $this->modx->getCacheManager()->delete('clientconfig',array(xPDO::OPT_CACHE_KEY => 'system_settings'));
         if ($this->modx->getOption('clientconfig.clear_cache', null, true)) {
             $this->modx->getCacheManager()->delete('',array(xPDO::OPT_CACHE_KEY => 'resource'));
         }
+        $this->modx->invokeEvent('ClientConfig_ConfigChange');
 
         // Return a response
         if ($this->hasErrors()) {


### PR DESCRIPTION
### What does it do ?
Flip the order so that plugins can immediately access new values

### Why is it needed ?
Right now the event still has the old values

Perhaps it makes sense to enhance this further by passing new values to the event, or immediately running ClientConfig::getSettings again to override the in-memory data. 

### Related issue(s)/PR(s)
Sebastian on Slack. 
