### PR TITLE
Fix GoogleFontList for MODX3

### DIFF
--- a/assets/components/clientconfig/js/mgr/widgets/combos.js
+++ b/assets/components/clientconfig/js/mgr/widgets/combos.js
@@ -70,7 +70,7 @@ ClientConfig.combo.GoogleFontList = function(config) {
     Ext.applyIf(config,{
         url: ClientConfig.config.connectorUrl,
         baseParams: {
-            action: 'mgr/fonts/google/getList',
+            action: 'mgr/fonts/google/getlist',
             combo: true
         },
         fields: ['family','name'],


### PR DESCRIPTION
### What does it do ?
Changes `getList` to `getlist`. 

### Why is it needed ?
MODX3 is stricter and needs the correct case-sensitive file path.

### Related issue
Fixes #204
