### PR TITLE
Improved editor for Ace settings

### DIFF
--- a/assets/components/clientconfig/js/mgr/sections/home.js
+++ b/assets/components/clientconfig/js/mgr/sections/home.js
@@ -115,6 +115,9 @@ Ext.extend(ClientConfig.page.Home,MODx.Component,{
                 if (field.xtype === 'code') {
                     field.height = 150;
                     field.xtype = Ext.ComponentMgr.isRegistered('modx-texteditor') ? 'modx-texteditor' : 'textarea';
+                    if (MODx.config.which_element_editor == 'Ace') {
+                        Ext.onReady(function() {MODx.ux.Ace.replaceComponent(field.id, 'text/html', 1);});
+                    }
                 }
 
                 if (field.xtype === 'richtext') {

--- a/core/components/clientconfig/processors/mgr/settings/save.class.php
+++ b/core/components/clientconfig/processors/mgr/settings/save.class.php
@@ -32,6 +32,11 @@ class cgSettingSaveProcessor extends modProcessor {
                 continue;
             }
 
+            // Fix save value for Ace setting
+            if ($setting->get('xtype') == 'code' && $this->modx->getOption('which_element_editor') == 'Ace') {
+                $value = $value[1];
+            }
+
             if (trim($value) === '' && $setting->get('is_required') &&
                 !in_array($setting->get('xtype'), array('checkbox', 'xcheckbox'), true)) {
                 $this->addFieldError($key, $setting->get('label') . ': ' . $this->modx->lexicon('clientconfig.field_is_required'));


### PR DESCRIPTION
### What does it do ?
Called `MODx.ux.Ace.replaceComponent()` which gives MODX tag and syntax highlighting.

The only oddity is that when saving, 2 values are given in value, because `MODx.ux.Ace.replaceComponent()` seems to create a new editor but not remove the old one. And I had to add `$value = $value[1];` to fix it. Maybe @Mark-H can give a better fix.

Before:
![cc_before](https://github.com/modmore/ClientConfig/assets/12523676/4e39c096-b4fc-44c6-a905-20da241d5ee1)

After:
![cc_after](https://github.com/modmore/ClientConfig/assets/12523676/0af1376e-54ce-4e44-a569-033fa5ae76df)

### Related issue(s)/PR(s)
N/A
