### PR TITLE
Fix Redactor not updating value on context switch

### DIFF
--- a/assets/components/clientconfig/js/mgr/clientconfig.class.js
+++ b/assets/components/clientconfig/js/mgr/clientconfig.class.js
@@ -24,10 +24,17 @@ Ext.extend(ClientConfig,Ext.Component,{
             ) {
                 CKEDITOR.instances[rte].destroy()
             }
+            // Redactor v2
             else if (window.$red) {
                 var editor = $red('#' + rte);
                 if (editor && editor.redactor) {
                     editor.redactor('core.destroy');
+                }
+            }
+            // Redactor v3
+            else if (window.Redactor) {
+                if (window.Redactor('#' + rte)) {
+                    $R('#' + rte, 'destroy');
                 }
             }
         }


### PR DESCRIPTION
For Redactor 3, due to a syntax change, the previous instance was not getting destroyed when switching. 

This PR ensures the instance is destroyed before initialising a new one.
